### PR TITLE
glog: populate symlinks -log_link directory (#64)

### DIFF
--- a/glog_file.go
+++ b/glog_file.go
@@ -132,6 +132,11 @@ func create(tag string, t time.Time) (f *os.File, filename string, err error) {
 			symlink := filepath.Join(dir, link)
 			os.Remove(symlink)        // ignore err
 			os.Symlink(name, symlink) // ignore err
+			if *logLink != "" {
+				lsymlink := filepath.Join(*logLink, link)
+				os.Remove(lsymlink)         // ignore err
+				os.Symlink(fname, lsymlink) // ignore err
+			}
 			return f, fname, nil
 		}
 		lastErr = err


### PR DESCRIPTION
This was reported in
https://groups.google.com/g/golang-nuts/c/Fh9o3CPjIIw/m/TyiUDY2uAAAJ.