### PR TITLE
glog: avoid calling user.Current() on windows (#69)

### DIFF
--- a/glog_file.go
+++ b/glog_file.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -68,9 +67,8 @@ func init() {
 		host = shortHostname(h)
 	}
 
-	current, err := user.Current()
-	if err == nil {
-		userName = current.Username
+	if u := lookupUser(); u != "" {
+		userName = u
 	}
 	// Sanitize userName since it is used to construct file paths.
 	userName = strings.Map(func(r rune) rune {

--- a/glog_file_nonwindows.go
+++ b/glog_file_nonwindows.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package glog
+
+import "os/user"
+
+func lookupUser() string {
+	if current, err := user.Current(); err == nil {
+		return current.Username
+	}
+	return ""
+}

--- a/glog_file_windows.go
+++ b/glog_file_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package glog
+
+import (
+	"syscall"
+)
+
+// This follows the logic in the standard library's user.Current() function, except
+// that it leaves out the potentially expensive calls required to look up the user's
+// display name in Active Directory.
+func lookupUser() string {
+	token, err := syscall.OpenCurrentProcessToken()
+	if err != nil {
+		return ""
+	}
+	defer token.Close()
+	tokenUser, err := token.GetTokenUser()
+	if err != nil {
+		return ""
+	}
+	username, _, accountType, err := tokenUser.User.Sid.LookupAccount("")
+	if err != nil {
+		return ""
+	}
+	if accountType != syscall.SidTypeUser {
+		return ""
+	}
+	return username
+}


### PR DESCRIPTION
Use the current process token to look up the user's name on Windows.

This is more reliable than using the USER or USERNAME environment variables, which are not always set, or might be overridden by the user accidentally or maliciously.

It follows the implementation of the user.Current() implementation in the standard library.

cl/650142356 (google-internal)